### PR TITLE
Update app version to 1.1.4, enable resource shrinking, and prevent native libraries extraction.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,14 +13,15 @@ android {
         applicationId = "com.bartixxx.opflashcontrol"
         minSdk = 31
         targetSdk = 35
-        versionCode = 16
-        versionName = "1.1.3"
+        versionCode = 17
+        versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         release {
+            isShrinkResources = true
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
+        android:extractNativeLibs="false"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"


### PR DESCRIPTION
… version to 1.1.4.

## Summary by Sourcery

Update app version to 1.1.4, enable resource shrinking, and prevent native libraries extraction.

Build:
- Set `extractNativeLibs` to `false` in the Android manifest.
- Enable resource shrinking for release builds.
- Bump version code to 17 and version name to "1.1.4".