### PR TITLE
Bump app version to 1.1.9 and adjust support button margin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         minSdk = 31
         targetSdk = 35
 
-        versionCode = 21
-        versionName = "1.1.8"
+        versionCode = 22
+        versionName = "1.1.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/layout/activity_supporters.xml
+++ b/app/src/main/res/layout/activity_supporters.xml
@@ -47,7 +47,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="16dp"
         app:backgroundTint="@color/material_dynamic_neutral70" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary by Sourcery

Update app version to 1.1.9 and adjust the margin of the support button.

Enhancements:
- Reduce the bottom margin of the support button in activity_supporters.xml from 24dp to 16dp.

Build:
- Bump app version code to 22.