### PR TITLE
Feat: Add support for two additional LEDs (led:torch_2 and led:torch_3)

### DIFF
--- a/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
@@ -121,10 +121,10 @@ class ExperimentalActivity : BaseActivity() {
                 try {
                     Log.d("ExperimentalActivity", "Light cycle: white LED on")
                     // Using the brightness from the slider
-                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = lightCycleBrightness, yellowBrightness = 0, showToast = false)
+                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE2_LED_PATH, YELLOW2_LED_PATH, whiteBrightness = lightCycleBrightness, white2Brightness = lightCycleBrightness, yellowBrightness = 0, yellow2Brightness = 0, showToast = false)
                     sleep(lightCycleDelay)  // Use slider value for delay
                     Log.d("ExperimentalActivity", "Light cycle: yellow LED on")
-                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = 0, yellowBrightness = lightCycleBrightness, showToast = false)
+                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE2_LED_PATH, YELLOW2_LED_PATH, whiteBrightness = 0, white2Brightness = 0, yellowBrightness = lightCycleBrightness, yellow2Brightness = lightCycleBrightness, showToast = false)
                     sleep(lightCycleDelay)
                 } catch (e: InterruptedException) {
                     Thread.currentThread().interrupt()
@@ -144,7 +144,7 @@ class ExperimentalActivity : BaseActivity() {
             Log.d("ExperimentalActivity", "Light thread interrupted")
         }
         lightThread = null
-        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = 0, yellowBrightness = 0, showToast = false)  // Turn LEDs off
+        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE2_LED_PATH, YELLOW2_LED_PATH,  whiteBrightness = 0, yellowBrightness = 0, white2Brightness = 0, yellow2Brightness = 0, showToast = false)  // Turn LEDs off
     }
 
     private fun startBrightnessCycle() {
@@ -159,7 +159,7 @@ class ExperimentalActivity : BaseActivity() {
                 try {
                     Log.d("ExperimentalActivity", "Brightness cycle: setting brightness to $brightness")
                     // Use the brightness from the slider
-                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = brightness, yellowBrightness = brightness, showToast = false)
+                    ledController.controlLeds("on", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE2_LED_PATH, YELLOW2_LED_PATH, whiteBrightness = brightness, yellowBrightness = brightness, white2Brightness = brightness, yellow2Brightness = brightness, showToast = false)
                     sleep(50) // Small delay for smooth transition
                     brightness += increment
                     if (brightness > 255 || brightness < 1) {
@@ -184,7 +184,7 @@ class ExperimentalActivity : BaseActivity() {
             Log.d("ExperimentalActivity", "Brightness thread interrupted")
         }
         brightnessThread = null
-        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = 0, yellowBrightness = 0, showToast = false)  // Turn LEDs off
+        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = 0, yellowBrightness = 0, white2Brightness = 0, yellow2Brightness = 0, showToast = false)  // Turn LEDs off
     }
 
     private fun navigateBackToMain() {

--- a/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
@@ -184,7 +184,7 @@ class ExperimentalActivity : BaseActivity() {
             Log.d("ExperimentalActivity", "Brightness thread interrupted")
         }
         brightnessThread = null
-        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE_LED_PATH, YELLOW_LED_PATH, whiteBrightness = 0, yellowBrightness = 0, white2Brightness = 0, yellow2Brightness = 0, showToast = false)  // Turn LEDs off
+        ledController.controlLeds("off", WHITE_LED_PATH, YELLOW_LED_PATH, WHITE2_LED_PATH, YELLOW2_LED_PATH, whiteBrightness = 0, yellowBrightness = 0, white2Brightness = 0, yellow2Brightness = 0, showToast = false)  // Turn LEDs off
     }
 
     private fun navigateBackToMain() {

--- a/app/src/main/java/com/bartixxx/opflashcontrol/LEDControlUtil.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/LEDControlUtil.kt
@@ -7,16 +7,12 @@ import android.widget.Toast
 import java.io.DataOutputStream
 import java.io.IOException
 import android.content.Context
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 class LedController {
 
     companion object {
         const val WHITE_LED_PATH = "/sys/class/leds/led:torch_0/brightness"
         const val YELLOW_LED_PATH = "/sys/class/leds/led:torch_1/brightness"
-        const val WHITE2_LED_PATH = "/sys/class/leds/led:torch_2/brightness"
-        const val YELLOW2_LED_PATH = "/sys/class/leds/led:torch_3/brightness"
         val TOGGLE_PATHS = listOf("/sys/class/leds/led:switch_2/brightness")
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor LED control and add support for two additional LEDs (led:torch_2 and led:torch_3), modifying the light cycle and brightness cycle functions to utilize all four LEDs. Improve error handling and retry mechanism in the LED control execution, adding exponential backoff and consolidating toast messages to the main thread. Include SELinux status check for debugging purposes.

New Features:
- Add support for controlling two additional LEDs (led:torch_2 and led:torch_3).

Enhancements:
- Improve the LED control logic by simplifying the on/off commands and using all four available LEDs.