### PR TITLE
Feat: Improve quick settings tile and adjust brightness levels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         minSdk = 31
         targetSdk = 35
 
-        versionCode = 33
-        versionName = "1.3.6"
+        versionCode = 34
+        versionName = "1.3.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Opflashcontrol"
         tools:targetApi="31">
+
         <service
             android:name=".LEDControlTileService"
             android:exported="true"
@@ -25,6 +26,15 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+
+        <!-- Dummy activity to override long press behavior on the Quick Settings Tile -->
+        <activity
+            android:name=".DummySettingsActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".SupportersActivity"
@@ -43,13 +53,11 @@
             android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Opflashcontrol"> <!-- Custom theme applied here -->
+            android:theme="@style/Theme.Opflashcontrol">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/bartixxx/opflashcontrol/DummySettingsActivity.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/DummySettingsActivity.kt
@@ -1,0 +1,12 @@
+package com.bartixxx.opflashcontrol
+
+import android.app.Activity
+import android.os.Bundle
+
+class DummySettingsActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Immediately finish so nothing is shown to the user.
+        finish()
+    }
+}

--- a/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/ExperimentalActivity.kt
@@ -14,7 +14,7 @@ class ExperimentalActivity : BaseActivity() {
     private var brightnessThread: Thread? = null
 
     private var lightCycleDelay: Long = 500  // Default delay
-    private var lightCycleBrightness: Int = 255  // Default brightness
+    private var lightCycleBrightness: Int = 500  // Default brightness
     private lateinit var ledController: LedController
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,8 +44,8 @@ class ExperimentalActivity : BaseActivity() {
 
         // Set up second slider for brightness control with vibration feedback
         binding.brightnessSeekBar.valueFrom = 0f
-        binding.brightnessSeekBar.value = 255f
-        binding.brightnessSeekBar.valueTo = 255f // Brightness range from 0 to 255
+        binding.brightnessSeekBar.value = 80f
+        binding.brightnessSeekBar.valueTo = 500f // Brightness range from 0 to 500
 
         // Add the listener to update brightness and TextView
         binding.brightnessSeekBar.addOnChangeListener { _, value, _ ->
@@ -193,7 +193,7 @@ class ExperimentalActivity : BaseActivity() {
                     )
                     sleep(50) // Small delay for smooth transition
                     brightness += increment
-                    if (brightness > 255 || brightness < 1) {
+                    if (brightness > 500 || brightness < 1) {
                         increment *= -1
                         brightness += increment * 2
                     }

--- a/app/src/main/java/com/bartixxx/opflashcontrol/MainActivity.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/MainActivity.kt
@@ -43,13 +43,13 @@ class MainActivity : BaseActivity() {
         with(binding) {
             masterSeekBar.valueFrom = 0f
             masterSeekBar.value = 80f
-            masterSeekBar.valueTo = 255f
+            masterSeekBar.valueTo = 500f
 
             whiteSeekBar.valueFrom = 0f
-            whiteSeekBar.valueTo = 255f
+            whiteSeekBar.valueTo = 500f
 
             yellowSeekBar.valueFrom = 0f
-            yellowSeekBar.valueTo = 255f
+            yellowSeekBar.valueTo = 500f
 
             setupSlider(masterSeekBar, masterTextView, "Master Brightness") { progress ->
                 if (!safetyTriggered) {

--- a/app/src/main/java/com/bartixxx/opflashcontrol/MainActivity2.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/MainActivity2.kt
@@ -40,19 +40,19 @@ class MainActivity2 : BaseActivity() {
         with(binding) {
             masterSeekBar.valueFrom = 0f
             masterSeekBar.value = 80f
-            masterSeekBar.valueTo = 255f
+            masterSeekBar.valueTo = 500f
 
             whiteSeekBar.valueFrom = 0f
-            whiteSeekBar.valueTo = 255f
+            whiteSeekBar.valueTo = 500f
 
             yellowSeekBar.valueFrom = 0f
-            yellowSeekBar.valueTo = 255f
+            yellowSeekBar.valueTo = 500f
 
             white2SeekBar2.valueFrom = 0f
-            white2SeekBar2.valueTo = 255f
+            white2SeekBar2.valueTo = 500f
 
             yellow2SeekBar3.valueFrom = 0f
-            yellow2SeekBar3.valueTo = 255f
+            yellow2SeekBar3.valueTo = 500f
 
             setupSlider(masterSeekBar, masterTextView, "Master Brightness") { progress ->
                 masterBrightness = progress

--- a/app/src/main/java/com/bartixxx/opflashcontrol/TileService.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/TileService.kt
@@ -130,7 +130,7 @@ class LEDControlTileService : TileService() {
                 if (brightnessExceededTime == 0L) {
                     brightnessExceededTime = currentTime
                     Log.d("LEDControlTileService", "Brightness exceeded safe limit, timer started.")
-                } else if (currentTime - brightnessExceededTime > 2000) { // More than 2 seconds.
+                } else if (currentTime - brightnessExceededTime > 20000) { // More than 20 seconds.
                     if (!safetyTriggered) {
                         Log.d("LEDControlTileService", "Safety triggered! Reducing brightness to 80.")
                         safetyTriggered = true

--- a/app/src/main/java/com/bartixxx/opflashcontrol/TileService.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/TileService.kt
@@ -22,7 +22,7 @@ class LEDControlTileService : TileService() {
 
     // Define brightness steps as absolute values.
     // We now include a low step of 20, along with 50, 80, 150, 250, and 500.
-    private val brightnessSteps = listOf(20, 50, 80, 150, 250, 500)
+    private val brightnessSteps = listOf(10, 20, 50, 80, 150, 250, 500)
     private val maxBrightness = 500
 
     private var lastTapTime: Long = 0L // For double-tap detection.

--- a/app/src/main/res/layout/activity_dummy_settings.xml
+++ b/app/src/main/res/layout/activity_dummy_settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DummySettingsActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ monitor = "1.7.2"
 recyclerview = "1.4.0"
 runtime = "1.7.6"
 uiText = "1.7.7"
-uiUnit = "1.7.7"
+uiUnit = "1.7.6"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ monitor = "1.7.2"
 recyclerview = "1.4.0"
 runtime = "1.7.6"
 uiText = "1.7.7"
-uiUnit = "1.7.6"
+uiUnit = "1.7.7"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }


### PR DESCRIPTION
## Summary by Sourcery

Improve the quick settings tile and adjust brightness levels.

New Features:
- Double-tapping the quick settings tile toggles between 80% brightness and off.

Tests:
- Updated tests to reflect changes in brightness levels and double-tap behavior.