### PR TITLE
Improve test coverage

### DIFF
--- a/app/src/main/java/com/bartixxx/opflashcontrol/LEDControlUtil.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/LEDControlUtil.kt
@@ -120,7 +120,7 @@ class LedController(private val context: Context) {
     }
 
 
-    protected fun executeRootCommands(commands: List<String>, showToast: Boolean = true) {
+    internal fun executeRootCommands(commands: List<String>, showToast: Boolean = true) {
         val maxRetries = 3 // Maximum number of retries
         val initialDelay = 1000L // Initial delay in milliseconds
         val maxDelay = 8000L // Maximum delay (8 seconds) for exponential backoff

--- a/app/src/main/java/com/bartixxx/opflashcontrol/LedPathUtil.kt
+++ b/app/src/main/java/com/bartixxx/opflashcontrol/LedPathUtil.kt
@@ -6,14 +6,13 @@ import java.io.File
 object LedPathUtil {
     private const val TAG = "LedPathUtil"
 
-    fun findLedPaths(): LedPaths {
-        val basePath = "/sys/class/leds/"
+    fun findLedPaths(baseDir: File = File("/sys/class/leds/")): LedPaths {
         val torchPaths = mutableListOf<String>()
         val flashPaths = mutableListOf<String>()
         val switchPaths = mutableListOf<String>()
 
         try {
-            val ledDirs = File(basePath).listFiles()
+            val ledDirs = baseDir.listFiles()
             ledDirs?.forEach { dir ->
                 val dirName = dir.name
                 when {

--- a/app/src/test/java/com/bartixxx/opflashcontrol/LedControllerTest.kt
+++ b/app/src/test/java/com/bartixxx/opflashcontrol/LedControllerTest.kt
@@ -1,0 +1,99 @@
+package com.bartixxx.opflashcontrol
+
+import android.content.Context
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+
+class LedControllerTest {
+
+    private lateinit var ledController: LedController
+    private val mockContext: Context = mock()
+
+    @Before
+    fun setUp() {
+        ledController = spy(LedController(mockContext))
+        // Stub the executeRootCommands method to do nothing
+        doNothing().`when`(ledController).executeRootCommands(any(), any())
+    }
+
+    @Test
+    fun `controlLeds with action on generates correct commands`() {
+        val whiteLedPath = "/sys/class/leds/white/brightness"
+        val yellowLedPath = "/sys/class/leds/yellow/brightness"
+        val togglePaths = listOf("/sys/class/leds/switch/brightness")
+
+        ledController.controlLeds(
+            action = "on",
+            whiteLedPath = whiteLedPath,
+            yellowLedPath = yellowLedPath,
+            togglePaths = togglePaths,
+            whiteBrightness = 100,
+            yellowBrightness = 200,
+            showToast = false
+        )
+
+        val expectedCommands = listOf(
+            "echo 0 > ${togglePaths[0]}",
+            "echo 100 > $whiteLedPath",
+            "echo 200 > $yellowLedPath",
+            "echo 255 > ${togglePaths[0]}"
+        )
+
+        verify(ledController).executeRootCommands(expectedCommands, false)
+    }
+
+    @Test
+    fun `controlLeds with action off generates correct commands`() {
+        val whiteLedPath = "/sys/class/leds/white/brightness"
+        val yellowLedPath = "/sys/class/leds/yellow/brightness"
+        val togglePaths = listOf("/sys/class/leds/switch/brightness")
+
+        ledController.controlLeds(
+            action = "off",
+            whiteLedPath = whiteLedPath,
+            yellowLedPath = yellowLedPath,
+            togglePaths = togglePaths,
+            whiteBrightness = 100,
+            yellowBrightness = 200,
+            showToast = false
+        )
+
+        val expectedCommands = listOf(
+            "echo 80 > $whiteLedPath",
+            "echo 80 > $yellowLedPath",
+            "echo 0 > ${togglePaths[0]}"
+        )
+
+        verify(ledController).executeRootCommands(expectedCommands, false)
+    }
+
+    @Test
+    fun `controlLeds with 0 brightness sanitizes to 1`() {
+        val whiteLedPath = "/sys/class/leds/white/brightness"
+        val yellowLedPath = "/sys/class/leds/yellow/brightness"
+        val togglePaths = emptyList<String>()
+
+        ledController.controlLeds(
+            action = "on",
+            whiteLedPath = whiteLedPath,
+            yellowLedPath = yellowLedPath,
+            togglePaths = togglePaths,
+            whiteBrightness = 0,
+            yellowBrightness = 0,
+            showToast = false
+        )
+
+        val expectedCommands = listOf(
+            "echo 1 > $whiteLedPath",
+            "echo 1 > $yellowLedPath"
+        )
+
+        verify(ledController).executeRootCommands(expectedCommands, false)
+    }
+}

--- a/app/src/test/java/com/bartixxx/opflashcontrol/LedPathUtilTest.kt
+++ b/app/src/test/java/com/bartixxx/opflashcontrol/LedPathUtilTest.kt
@@ -1,0 +1,87 @@
+package com.bartixxx.opflashcontrol
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class LedPathUtilTest {
+
+    @Mock
+    private lateinit var mockBaseDir: File
+
+    @Mock
+    private lateinit var mockTorch1: File
+
+    @Mock
+    private lateinit var mockTorch2: File
+
+    @Mock
+    private lateinit var mockTorch3: File
+
+    @Mock
+    private lateinit var mockTorch4: File
+
+    @Mock
+    private lateinit var mockFlash1: File
+
+    @Mock
+    private lateinit var mockFlash2: File
+
+    @Mock
+    private lateinit var mockFlash3: File
+
+    @Mock
+    private lateinit var mockFlash4: File
+
+    @Mock
+    private lateinit var mockSwitch1: File
+
+    @Before
+    fun setUp() {
+        // Mock the directory structure
+        whenever(mockBaseDir.listFiles()).thenReturn(arrayOf(mockTorch1, mockTorch2, mockTorch3, mockTorch4, mockFlash1, mockFlash2, mockFlash3, mockFlash4, mockSwitch1))
+
+        // Mock the names of the directories
+        whenever(mockTorch1.name).thenReturn("led:torch1")
+        whenever(mockTorch2.name).thenReturn("led:torch2")
+        whenever(mockTorch3.name).thenReturn("led:torch3")
+        whenever(mockTorch4.name).thenReturn("led:torch4")
+        whenever(mockFlash1.name).thenReturn("led:flash1")
+        whenever(mockFlash2.name).thenReturn("led:flash2")
+        whenever(mockFlash3.name).thenReturn("led:flash3")
+        whenever(mockFlash4.name).thenReturn("led:flash4")
+        whenever(mockSwitch1.name).thenReturn("led:switch1")
+
+        // Mock the absolute paths
+        whenever(mockTorch1.absolutePath).thenReturn("/sys/class/leds/led:torch1")
+        whenever(mockTorch2.absolutePath).thenReturn("/sys/class/leds/led:torch2")
+        whenever(mockTorch3.absolutePath).thenReturn("/sys/class/leds/led:torch3")
+        whenever(mockTorch4.absolutePath).thenReturn("/sys/class/leds/led:torch4")
+        whenever(mockFlash1.absolutePath).thenReturn("/sys/class/leds/led:flash1")
+        whenever(mockFlash2.absolutePath).thenReturn("/sys/class/leds/led:flash2")
+        whenever(mockFlash3.absolutePath).thenReturn("/sys/class/leds/led:flash3")
+        whenever(mockFlash4.absolutePath).thenReturn("/sys/class/leds/led:flash4")
+        whenever(mockSwitch1.absolutePath).thenReturn("/sys/class/leds/led:switch1")
+    }
+
+    @Test
+    fun `findLedPaths correctly identifies and assigns paths`() {
+        val ledPaths = LedPathUtil.findLedPaths(mockBaseDir)
+
+        assertEquals("/sys/class/leds/led:torch1/brightness", ledPaths.WHITE_LED_PATH)
+        assertEquals("/sys/class/leds/led:torch2/brightness", ledPaths.YELLOW_LED_PATH)
+        assertEquals("/sys/class/leds/led:torch3/brightness", ledPaths.WHITE2_LED_PATH)
+        assertEquals("/sys/class/leds/led:torch4/brightness", ledPaths.YELLOW2_LED_PATH)
+        assertEquals("/sys/class/leds/led:flash1/brightness", ledPaths.FLASH_WHITE_LED_PATH)
+        assertEquals("/sys/class/leds/led:flash2/brightness", ledPaths.FLASH_YELLOW_LED_PATH)
+        assertEquals("/sys/class/leds/led:flash3/brightness", ledPaths.FLASH_WHITE2_LED_PATH)
+        assertEquals("/sys/class/leds/led:flash4/brightness", ledPaths.FLASH_YELLOW2_LED_PATH)
+        assertEquals(listOf("/sys/class/leds/led:switch1/brightness"), ledPaths.TOGGLE_PATHS)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ recyclerview = "1.4.0"
 runtime = "1.8.3"
 uiText = "1.8.3"
 uiUnit = "1.9.2"
+mockitoCore = "5.20.0"
+mockitoKotlin = "6.1.0"
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -31,6 +33,8 @@ androidx-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "uiTe
 compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoCore" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
This change adds unit tests for `LedController` and `LedPathUtil`, improving the test coverage of the application. It also configures the JaCoCo plugin to generate test coverage reports.

---
*PR created automatically by Jules for task [11673429971702162815](https://jules.google.com/task/11673429971702162815) started by @Bartixxx32*

## Summary by Sourcery

Add unit tests and coverage tooling to improve reliability of LED control utilities.

Enhancements:
- Make LedPathUtil.findLedPaths accept a base directory parameter to allow easier testing and flexibility.
- Relax LedController.executeRootCommands visibility to internal to support unit testing via spies.

Build:
- Enable JaCoCo in the app module and configure a jacocoTestReport task to generate XML and HTML coverage reports for debug unit tests.
- Add JUnit and Mockito (core and Kotlin) as test dependencies and wire their versions into the shared versions catalog.

Tests:
- Add unit tests for LedController to verify generated root commands for different actions and brightness values.
- Add unit tests for LedPathUtil using a mock filesystem to validate LED path discovery and mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for LED control command generation and system path discovery.

* **Chores**
  * Integrated code coverage instrumentation and test framework dependencies to enhance test quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->